### PR TITLE
changed bounds

### DIFF
--- a/lib/project/motion-capture.rb
+++ b/lib/project/motion-capture.rb
@@ -243,7 +243,7 @@ module Motion; class Capture
 
   def preview_layer_for_view(view, options = {})
     AVCaptureVideoPreviewLayer.layerWithSession(session).tap do |layer|
-      layer_bounds = view.layer.bounds
+      layer_bounds = CGRectMake(0, 0, App.window.frame.size.width, App.window.frame.size.height)
 
       layer.bounds       = layer_bounds
       layer.position     = CGPointMake(CGRectGetMidX(layer_bounds), CGRectGetMidY(layer_bounds))


### PR DESCRIPTION
The `view.layer.bounds` caused the preview layer to be enlarged and a good portion of the camera image was not displayed in the view. Pulling from `App.window.frame` appears to resolve this.
